### PR TITLE
Fix the quickform closing after changed focus again

### DIFF
--- a/resources/assets/scripts/codice.js
+++ b/resources/assets/scripts/codice.js
@@ -45,23 +45,24 @@ var $quickformControls = $('.quickform .row');
 var $quickformContent = $('#quickform_content');
 
 $quickformContent.on('focus', function () {
-    $(this).slideDown('slow', function() {
-        $(this).attr('rows', '4');
+    $(this).slideDown('slow', function () {
+        $quickformContent.attr('rows', '4');
         $quickformControls.removeClass('sr-only');
     });
 });
 
-$('.quickform').on('focusout', function (e) {
-    var $this = $(this);
-    if (
-        $quickformContent.val() === '' &&
-        !$(e.relatedTarget).parent().closest('.row').length
-    ) {
-        $quickformContent.attr('rows', '1');
+var $quickformCollapseButton = $(
+    '<button type="button" class="btn btn-default quickform-collapse">' +
+        '<span class="sr-only">' +
+            codiceLang.collapse +
+        '</span>' +
+        '<span class="fa fa-angle-double-up aria-hidden="true"></span>' +
+    '</button>')
+    .insertBefore($('.quickform-submit').removeClass('btn-block'))
+    .click(function () {
         $quickformControls.addClass('sr-only');
-        e.stopPropagation();
-    }
-});
+        $quickformContent.attr('rows', 1);
+    });
 
 function codiceDatetimePicker(domSelector) {
     $(domSelector).datetimepicker({

--- a/resources/assets/scripts/locales/en.js
+++ b/resources/assets/scripts/locales/en.js
@@ -5,4 +5,5 @@ var codiceLang = {
     confirmUninstall: "Do you really want to uninstall?",
     languageCode: "en",
     selectLabels: "Choose labels",
+    collapse: "Collapse",
 };

--- a/resources/assets/scripts/locales/pl.js
+++ b/resources/assets/scripts/locales/pl.js
@@ -5,4 +5,5 @@ var codiceLang = {
     confirmUninstall: "Czy na pewno odinstalować?",
     languageCode: "pl",
     selectLabels: "Wybierz etykiety",
+    collapse: "Zwiń",
 };

--- a/resources/assets/styles/_forms.scss
+++ b/resources/assets/styles/_forms.scss
@@ -23,4 +23,8 @@ textarea#quickform_content {
     .select2-search__field {
         width: 100% !important;
     }
+
+    .quickform-collapse + .quickform-submit {
+        float: right;
+    }
 }

--- a/resources/views/note/quickform.blade.php
+++ b/resources/views/note/quickform.blade.php
@@ -24,7 +24,7 @@ Just @include the view and pass following parameters:
                 <input type="text" name="expires_at" id="quickform_expires_at" class="form-control" placeholder="{{ datetime_placeholder('note.labels.expires_at') }}">
             </div>
             <div class="col-md-2">
-                <button type="submit" class="btn btn-primary btn-block">@lang('note.create.submit')</button>
+                <button type="submit" class="btn btn-primary quickform-submit">@lang('note.create.submit')</button>
             </div>
         </div>
         {{ csrf_field() }}


### PR DESCRIPTION
Fixes the quickform being collapsed after the focus is switched to another field in the form. Also adds a dedicated button to collapse the form manually (which may require some additional theming).
