### PR TITLE
Fixed calendar month name UX issue #19

### DIFF
--- a/resources/assets/styles/_calendar.scss
+++ b/resources/assets/styles/_calendar.scss
@@ -1,3 +1,9 @@
+.calendar-month-name {
+  width: 170px;
+  display: inline-block;
+  text-align: center;
+}
+
 table.calendar {
   border-collapse: separate;
   border-spacing: 15px;

--- a/resources/views/calendar/month.blade.php
+++ b/resources/views/calendar/month.blade.php
@@ -5,7 +5,7 @@
     @lang('calendar.title')
     <span class="page-heading-aside">
         <a href="{!! $month_previous !!}">@icon('arrow-left') <span class="sr-only">@lang('calendar.month.previous')</span></a>
-        @lang("calendar.months.$month") {{ $year }}
+        <span class="calendar-month-name">@lang("calendar.months.$month") {{ $year }}</span>
         <a href="{!! $month_next !!}"><span class="sr-only">@lang('calendar.month.next')</span> @icon('arrow-right')</a>
     </span>
 </h2>


### PR DESCRIPTION
Month name in calendar now has fixed length
which prevents the change of right arrow position.
